### PR TITLE
Validate proper address length based on whether it is a B or Z address.

### DIFF
--- a/src/main/java/org/btcprivate/wallets/fullnode/ui/SendCashPanel.java
+++ b/src/main/java/org/btcprivate/wallets/fullnode/ui/SendCashPanel.java
@@ -378,24 +378,6 @@ public class SendCashPanel
         // Z Addresses are 95 chars (zk)
         // base58check encoded
 
-        String errorMessage = null;
-
-        if ((sourceAddress == null) || (sourceAddress.trim().length() < 35))
-        {
-            errorMessage = "'From' address is invalid; it is too short or missing.";
-        } else if (sourceAddress.trim().length() > 95)
-        {
-            errorMessage = "'From' address is invalid; it is too long.";
-        }
-
-        if ((destinationAddress == null) || (destinationAddress.trim().length() < 35))
-        {
-            errorMessage = "Destination address is invalid; it is too short or missing.";
-        } else if (destinationAddress.trim().length() > 95)
-        {
-            errorMessage = "Destination address is invalid; it is too long.";
-        }
-
         // Prevent accidental sending to non-BTCP addresses (as seems to be supported by daemon)
         if (!installationObserver.isOnTestNet())
         {
@@ -419,6 +401,29 @@ public class SendCashPanel
 
                 return; // Do not send anything!
             }
+        }
+        
+        String errorMessage = null;
+
+        int sourceAddressProperLength = 35;
+		if (sourceAddress.startsWith("zk")) sourceAddressProperLength = 95;
+		int destinationAddressProperLength = 35;
+		if (destinationAddress.startsWith("zk")) destinationAddressProperLength = 95;
+
+        if ((sourceAddress == null) || (sourceAddress.trim().length() < sourceAddressProperLength))
+        {
+            errorMessage = "'From' address is invalid; it is too short or missing.";
+        } else if (sourceAddress.trim().length() > sourceAddressProperLength)
+        {
+            errorMessage = "'From' address is invalid; it is too long.";
+        }
+
+        if ((destinationAddress == null) || (destinationAddress.trim().length() < destinationAddressProperLength))
+        {
+            errorMessage = "Destination address is invalid; it is too short or missing.";
+        } else if (destinationAddress.trim().length() > destinationAddressProperLength)
+        {
+            errorMessage = "Destination address is invalid; it is too long.";
         }
 
         if ((amount == null) || (amount.trim().length() <= 0))

--- a/src/main/java/org/btcprivate/wallets/fullnode/ui/SendCashPanel.java
+++ b/src/main/java/org/btcprivate/wallets/fullnode/ui/SendCashPanel.java
@@ -405,10 +405,10 @@ public class SendCashPanel
         
         String errorMessage = null;
 
-		final int BADDRESSPROPERLENGTH = 35;
-		final int ZADDRESSPROPERLENGTH = 95;
-		int sourceAddressProperLength = (sourceAddress.startsWith("zk")) ? ZADDRESSPROPERLENGTH : BADDRESSPROPERLENGTH;
-		int destinationAddressProperLength = (destinationAddress.startsWith("zk")) ? ZADDRESSPROPERLENGTH : BADDRESSPROPERLENGTH;
+		final int B_ADDRESS_PROPER_LENGTH = 35;
+		final int Z_ADDRESS_PROPER_LENGTH = 95;
+		int sourceAddressProperLength = (sourceAddress.startsWith("zk")) ? Z_ADDRESS_PROPER_LENGTH : B_ADDRESS_PROPER_LENGTH;
+		int destinationAddressProperLength = (destinationAddress.startsWith("zk")) ? Z_ADDRESS_PROPER_LENGTH : B_ADDRESS_PROPER_LENGTH;
 
         if ((sourceAddress == null) || (sourceAddress.trim().length() < sourceAddressProperLength))
         {

--- a/src/main/java/org/btcprivate/wallets/fullnode/ui/SendCashPanel.java
+++ b/src/main/java/org/btcprivate/wallets/fullnode/ui/SendCashPanel.java
@@ -405,10 +405,10 @@ public class SendCashPanel
         
         String errorMessage = null;
 
-        int sourceAddressProperLength = 35;
-		if (sourceAddress.startsWith("zk")) sourceAddressProperLength = 95;
-		int destinationAddressProperLength = 35;
-		if (destinationAddress.startsWith("zk")) destinationAddressProperLength = 95;
+		final int BADDRESSPROPERLENGTH = 35;
+		final int ZADDRESSPROPERLENGTH = 95;
+		int sourceAddressProperLength = (sourceAddress.startsWith("zk")) ? ZADDRESSPROPERLENGTH : BADDRESSPROPERLENGTH;
+		int destinationAddressProperLength = (destinationAddress.startsWith("zk")) ? ZADDRESSPROPERLENGTH : BADDRESSPROPERLENGTH;
 
         if ((sourceAddress == null) || (sourceAddress.trim().length() < sourceAddressProperLength))
         {


### PR DESCRIPTION
Length validation checks precisely for length of 35 or 95 chars depending on whether its a B or Z address. Addresses of length between 36-94 chars are always invalidated.